### PR TITLE
feat: Add file logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,17 @@ func NewAuthenticator() *Authenticator {
 // --- Main Application Logic ---
 
 func main() {
+	// Initialize file logging
+	logFile, err := os.OpenFile(filepath.Join(getExecutableDir(), "slipstream.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Printf("Warning: Failed to open log file: %v", err)
+	} else {
+		defer logFile.Close()
+		// Create a multi-writer to write to both stdout and the log file
+		mw := io.MultiWriter(os.Stdout, logFile)
+		log.SetOutput(mw)
+	}
+
 	// 1. Load configuration.
 	cfg, err := loadConfig()
 	if err != nil {

--- a/slipstream.log
+++ b/slipstream.log
@@ -1,0 +1,7 @@
+2025/07/08 19:08:03 INFO: Rocket League Path Setup - Please locate your Rocket League executable (e.g., RocketLeague.exe). This will only be asked once.
+2025/07/08 19:08:03 ERROR: Configuration Error - Failed to load configuration.
+
+Please ensure that the program has permissions to read and write 'config.json' in its directory, and that the file is not corrupted.
+If the problem persists, you can try deleting 'config.json' and the program will attempt to recreate it.
+
+Details: you must select a path to continue


### PR DESCRIPTION
Log output will now be written to both the console and slipstream.log in the executable's directory. This will help with troubleshooting user-submitted issues.