### PR TITLE
Update Slipstream for Rocket League EAC integration and BakkesMod deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The game will launch, and your settings will be saved in the `config.json` file.
 *   **Custom Launch Options**:
     1.  In Steam, right-click Slipstream -> **Properties...**
     2.  Under **General**, enter options in **Launch Options** (e.g., `-nomovie -high`). These are passed to Rocket League.
+    *   **To launch without Easy Anti-Cheat (EAC):** Add `-noeac` to your launch options. Slipstream will intercept this and launch the base game executable instead, allowing for offline play and modding.
 *   **Multiple Accounts**:
     1.  Create a **new, separate folder** for each account.
     2.  Copy the Slipstream executable into each new folder.
@@ -48,6 +49,8 @@ The game will launch, and your settings will be saved in the `config.json` file.
 
 <details>
 <summary>Optional: BakkesMod Setup</summary>
+
+**DEPRECATION WARNING: BakkesMod is no longer in active development and is blocked by Easy Anti-Cheat.** Slipstream now treats BakkesMod as a "Legacy Offline" feature. If BakkesMod is enabled in `config.json`, Slipstream will automatically force the game to launch without EAC (effectively applying the `-noeac` flag automatically), restricting you to offline modes only. To play online, you must disable BakkesMod in your configuration.
 
 Slipstream can automatically launch BakkesMod. If enabled during initial setup, you'll be prompted for `BakkesMod.exe`.
 
@@ -72,6 +75,9 @@ For detailed Linux help, see the [BakkesLinux guide](https://github.com/CrumblyL
 
 <details>
 <summary>FAQ & Troubleshooting</summary>
+
+#### Q: How does Slipstream handle Easy Anti-Cheat (EAC)?
+**A:** Slipstream automatically detects your game path and launches the `RocketLeague_EAC.exe` version by default, ensuring online play works out-of-the-box. Existing users do not need to update their `config.json`; Slipstream intercepts the launch and corrects the path in memory. If you wish to play offline without EAC, add `-noeac` to your launch options.
 
 #### Q: Do I still need the Epic Games Launcher installed?
 Yes (or an alternative like Heroic), for installing and updating Rocket League. Slipstream lets you play without running the Epic Launcher.

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 // --- Constants ---
 const (
-	currentVersion = "v1.5.1"
+	currentVersion = "v1.6.0"
 
 	// API Configuration
 	epicAPIURL       = "https://account-public-service-prod.ak.epicgames.com/account/api"
@@ -304,8 +304,34 @@ func launchGame(cfg Config, creds LaunchCredentials, extraArgs []string) error {
 		return nil // Expected outcome on Linux with .exe path
 	}
 
+	useEAC := true
+	filteredExtraArgs := []string{}
+	for _, arg := range extraArgs {
+		if strings.ToLower(arg) == "-noeac" {
+			useEAC = false
+		} else {
+			filteredExtraArgs = append(filteredExtraArgs, arg)
+		}
+	}
+
+	if cfg.BakkesModEnabled {
+		useEAC = false
+	}
+
+	rlDir := filepath.Dir(cfg.RocketLeaguePath)
+	rlFilename := filepath.Base(cfg.RocketLeaguePath)
+	rlFilenameLower := strings.ToLower(rlFilename)
+
+	if rlFilenameLower == "rocketleague.exe" || rlFilenameLower == "rocketleague_eac.exe" {
+		if useEAC {
+			cfg.RocketLeaguePath = filepath.Join(rlDir, "RocketLeague_EAC.exe")
+		} else {
+			cfg.RocketLeaguePath = filepath.Join(rlDir, "RocketLeague.exe")
+		}
+	}
+
 	// 2. Launch Rocket League (asynchronously).
-	log.Println("Launching Rocket League...")
+	log.Printf("Launching Rocket League... (Executable: %s)", cfg.RocketLeaguePath)
 	rlArgs := []string{
 		"-AUTH_LOGIN=unused",
 		"-AUTH_PASSWORD=" + creds.ExchangeCode,
@@ -316,7 +342,7 @@ func launchGame(cfg Config, creds LaunchCredentials, extraArgs []string) error {
 		"-epicusername=\"\"", // Intentionally empty as per original args
 		"-epicuserid=" + creds.AccountID,
 	}
-	rlArgs = append(rlArgs, extraArgs...)
+	rlArgs = append(rlArgs, filteredExtraArgs...)
 	rlCmd := exec.Command(cfg.RocketLeaguePath, rlArgs...)
 
 	if err := rlCmd.Start(); err != nil {
@@ -468,7 +494,7 @@ func loadConfig() (Config, error) {
 		rlPath, err := zenity.SelectFile(
 			zenity.Title("Select Rocket League Executable"),
 			zenity.FileFilters{
-				{Name: "Rocket League Executable", Patterns: []string{"RocketLeague.exe", "RocketLeague"}, CaseFold: true},
+				{Name: "Rocket League Executable", Patterns: []string{"RocketLeague.exe", "RocketLeague_EAC.exe", "RocketLeague"}, CaseFold: true},
 				{Name: "All Files", Patterns: []string{"*"}},
 			},
 		)
@@ -486,8 +512,8 @@ func loadConfig() (Config, error) {
 	// BakkesMod Setup Prompt - only if RL path is set and BM not already configured or declined
 	if cfg.RocketLeaguePath != "" && cfg.BakkesModPath == "" && !cfg.BakkesModSetupDeclined {
 		log.Println("Prompting for BakkesMod setup.")
-		err := zenity.Question("Would you like to enable automatic launching for BakkesMod?",
-			zenity.Title("BakkesMod Setup"),
+		err := zenity.Question("Would you like to enable legacy BakkesMod support?\n\nWARNING: BakkesMod has been discontinued and no longer works online. Enabling this will launch the game without Anti-Cheat, meaning you will only be able to play offline modes (Free Play, Replays, Custom Training).",
+			zenity.Title("BakkesMod Setup (Legacy/Offline)"),
 			zenity.DefaultCancel(), // Makes "No" the default if user just closes dialog
 			zenity.OKLabel("Yes"),
 			zenity.CancelLabel("No"),


### PR DESCRIPTION
Updated `launchGame` in `main.go` to handle the new `RocketLeague_EAC.exe` requirement, process the `-noeac` flag, and adjust logic for BakkesMod. Also updated the BakkesMod configuration prompt and README.md.

---
*PR created automatically by Jules for task [15282996659303073371](https://jules.google.com/task/15282996659303073371) started by @JunoLK*